### PR TITLE
coerce to nil

### DIFF
--- a/bodyless.go
+++ b/bodyless.go
@@ -8,6 +8,10 @@ import (
 type (
 	Null      struct{}
 	Undefined struct{}
+
+	Bodyless interface {
+		IsBodyless() bool
+	}
 )
 
 var (
@@ -19,8 +23,10 @@ func (n *Null) Decode(r io.Reader) error        { return nil }
 func (n *Null) Encode(w io.Writer) (int, error) { return 0, nil }
 func (n *Null) Marker() byte                    { return 0x05 }
 func (n *Null) Native() reflect.Type            { return reflect.TypeOf(n).Elem() }
+func (n *Null) IsBodyless() bool                { return true }
 
 func (u *Undefined) Decode(r io.Reader) error        { return nil }
 func (u *Undefined) Encode(w io.Writer) (int, error) { return 0, nil }
 func (u *Undefined) Marker() byte                    { return 0x06 }
 func (u *Undefined) Native() reflect.Type            { return reflect.TypeOf(u).Elem() }
+func (u *Undefined) IsBodyless() bool                { return true }

--- a/encoding/marshaler.go
+++ b/encoding/marshaler.go
@@ -31,6 +31,9 @@ func NewMarshaler() *Marshaler {
 // through each field of a type one-by-one and marshals it by converting to its
 // AMF type. If a field is already an AMF type, it marshals it directly. It does
 // not recurse to embedded fields.
+//
+// If the field is nil (i.e., an uninitialized pointer), then an amf0.Null will
+// be written, instead of the actual type.
 func (m *Marshaler) Marshal(dest interface{}) ([]byte, error) {
 	buf := new(bytes.Buffer)
 
@@ -50,6 +53,10 @@ func (m *Marshaler) Marshal(dest interface{}) ([]byte, error) {
 }
 
 func (m *Marshaler) convertToAmfType(val reflect.Value) (amf0.AmfType, error) {
+	if val.Kind() == reflect.Ptr && val.IsNil() {
+		return new(amf0.Null), nil
+	}
+
 	amfType := m.i.AmfType(val.Interface())
 	if amfType == nil {
 		return nil, noMatchingType(val.Type().String())

--- a/encoding/marshaler_test.go
+++ b/encoding/marshaler_test.go
@@ -35,3 +35,12 @@ func TestMarshallingNonNativeMembers(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, []byte{0x3, 0x0, 0x0, 0x9}, buf)
 }
+
+func TestMarshallingNilTypes(t *testing.T) {
+	buf, err := encoding.Marshal(&struct {
+		Foo *amf0.Object
+	}{ /* Foo will be a nil pointer */ })
+
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{0x05}, buf)
+}

--- a/encoding/unmarshaler.go
+++ b/encoding/unmarshaler.go
@@ -32,6 +32,9 @@ func NewUnmarshaler(r io.Reader) *Unmarshaler {
 
 // Unmarshal fills each field in the givne interface{} with the AMF data on the
 // stream in-order.
+//
+// If a value of amf0.Null or amf0.Undefined is read, then the value will be
+// skipped.
 func (u *Unmarshaler) Unmarshal(dest interface{}) error {
 	v := reflect.ValueOf(dest).Elem()
 
@@ -43,9 +46,21 @@ func (u *Unmarshaler) Unmarshal(dest interface{}) error {
 			return err
 		}
 
+		if u.isBodyless(next) {
+			continue
+		}
+
 		val := reflect.ValueOf(next).Elem()
 		field.Set(val.Convert(field.Type()))
 	}
 
 	return nil
+}
+
+// isBodyless returns a bool representing whether or not the given amf0.Type is
+// bodyless or not.
+func (u *Unmarshaler) isBodyless(t amf0.AmfType) bool {
+	_, isBodyless := t.(amf0.Bodyless)
+
+	return isBodyless
 }

--- a/encoding/unmarshaler.go
+++ b/encoding/unmarshaler.go
@@ -60,7 +60,9 @@ func (u *Unmarshaler) Unmarshal(dest interface{}) error {
 // isBodyless returns a bool representing whether or not the given amf0.Type is
 // bodyless or not.
 func (u *Unmarshaler) isBodyless(t amf0.AmfType) bool {
-	_, isBodyless := t.(amf0.Bodyless)
+	if v, isBodyless := t.(amf0.Bodyless); isBodyless {
+		return v.IsBodyless()
+	}
 
-	return isBodyless
+	return false
 }

--- a/encoding/unmarshaler_test.go
+++ b/encoding/unmarshaler_test.go
@@ -40,3 +40,16 @@ func TestStructScanWithoutConverstion(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, amf0.Bool(true), target.Foo)
 }
+
+func TestStrucScanWithNil(t *testing.T) {
+	target := struct {
+		Foo *amf0.Object
+	}{}
+
+	err := encoding.Unmarshal(bytes.NewBuffer([]byte{
+		0x05, // <null>
+	}), &target)
+
+	assert.Nil(t, err)
+	assert.Nil(t, target.Foo)
+}


### PR DESCRIPTION
This PR introduces some additional behavior in the `encoding.Marshaler` and `encoding.Unmarshaler` types to more correctly serialize `nil`-like values.

For example, if previously a nil pointer was stored in some value and we tried to serialize it, all sorts of hell would occur. Now, amf0 simply detects that the value is nil-ish and writes `0x05` (the nil marker) instead.

The same behavior has been introduced for going the opposite direction (`io.Reader` -> `struct`).

I also created the `Bodyless` interface which is a tag-type interface that allows us to more easily check whether or not a given `AmfType` is body-less. This was done since there are multiple amf0 types which mean this (see: `amf0.Null` and `amf0.Undefined`).
