### PR TITLE
natives: don't use go string types for long strings

### DIFF
--- a/string.go
+++ b/string.go
@@ -46,7 +46,7 @@ func (s *String) Encode(w io.Writer) (int, error) {
 }
 
 func (l *LongString) Marker() byte         { return 0x0c }
-func (l *LongString) Native() reflect.Type { return reflect.TypeOf("") }
+func (l *LongString) Native() reflect.Type { return reflect.TypeOf(l) }
 func (l *LongString) Decode(r io.Reader) error {
 	if v, err := strDecode(r, 4); err != nil {
 		return err


### PR DESCRIPTION
This pull-request makes it so that, by default amf0 serializes and de-serializes strings into the `amf0.String` (not `amf0.LongString`) type.

This change aligns with our current methodology of _not_ adding extra struct tags to fields, and instead specifying deserialization with the types instead. That way, to use a LongString, you will actually have to declare your fields as:

``` go
type T struct {
        Foo amf0.LongString
}
```

Potentially it would be nice to switch between the two based on length, but that will be a future change as I am not yet sure if that is the right way to go.
