### PR TITLE
unmarshal: be able to decode into pointers/raws with higher accuracy

### DIFF
--- a/encoding/unmarshaler_test.go
+++ b/encoding/unmarshaler_test.go
@@ -15,6 +15,58 @@ func TestUnmarshallerConstruction(t *testing.T) {
 	assert.IsType(t, &encoding.Unmarshaler{}, s)
 }
 
+func TestUnmarshallingANonNilPointerValue(t *testing.T) {
+	target := struct {
+		Foo *amf0.Bool
+	}{}
+
+	err := encoding.Unmarshal(bytes.NewReader([]byte{
+		0x01, 0x01, // <bool>, <true>
+	}), &target)
+
+	assert.Nil(t, err)
+	assert.EqualValues(t, true, *target.Foo)
+}
+
+func TestUnmarshallingANonNilValue(t *testing.T) {
+	target := struct {
+		Foo amf0.Bool
+	}{}
+
+	err := encoding.Unmarshal(bytes.NewReader([]byte{
+		0x01, 0x01, // <bool>, <true>
+	}), &target)
+
+	assert.Nil(t, err)
+	assert.EqualValues(t, true, target.Foo)
+}
+
+func TestUnmarshallingANilPointerValue(t *testing.T) {
+	target := struct {
+		Foo *amf0.Bool
+	}{}
+
+	err := encoding.Unmarshal(bytes.NewReader([]byte{
+		0x05, // <null>
+	}), &target)
+
+	assert.Nil(t, err)
+	assert.Nil(t, target.Foo)
+}
+
+func TestUnmarshallingANilValue(t *testing.T) {
+	target := struct {
+		Foo amf0.Bool
+	}{}
+
+	err := encoding.Unmarshal(bytes.NewReader([]byte{
+		0x05, // <null>
+	}), &target)
+
+	assert.Equal(t, "amf0: unable to assign nil to type amf0.Bool",
+		err.Error())
+}
+
 func TestSimpleUnmarshal(t *testing.T) {
 	target := struct {
 		Foo bool


### PR DESCRIPTION
This pull-request allows the unmarshal operation to better understand which types are convertible into which other types.

Previously, if an `*amf0.String` was decoded, and we wanted to serialize into `amf0.String`, that was not possible. This pull-request rectifies that issue.

This is particularly useful for being able to specify optional/non-optional parameters by using the pointer type `*T` instead of the raw type `T`. Previously, you were only able to use `amf0.Object`, thus making an optional object not possible. Now you're able to!
